### PR TITLE
Correct issue with params on directive

### DIFF
--- a/src/core/gp-translate.directive.ts
+++ b/src/core/gp-translate.directive.ts
@@ -80,16 +80,16 @@ export class GpTranslateDirective implements OnInit {
       const paramMap = this._params;
       const promises = [];
       for (const key in paramMap) {
-          if (paramMap[key]) {
-              const keyText = paramMap[key];
-              promises.push(this.parse(key, keyText));
-          }
+        if (paramMap.hasOwnProperty(key)) {
+            const keyText = paramMap[key];
+            promises.push(this.parse(key, keyText));
+        }
       }
       return Promise.all(promises)
         .then((results) => {
             for (const k in results) {
                 if (results[k]) {
-                    const replaceStr = '{' + results[k][0] + '}';
+                    const replaceStr = '{{' + results[k][0] + '}}';
                     if (originaltext) {
                         originaltext = originaltext.replace(replaceStr, results[k][1]);
                     }


### PR DESCRIPTION
Hi @jugu 

We just found out that the issue I had corrected with the '{{...}}' for the params was not complete : I have done it in the service, but forgot the directive. 
This pull request is for correcting the directive part. 

Commit message :
The directive was still using only '{...}' for params,
while it should use '{{...}}'.
Also if a param value was 0 or false, it would not be displayed.

Please let me know what you think of it. 

Thank you,
Camille