### PR TITLE
Revert to the default language if resource string key is not found

### DIFF
--- a/src/core/gp-translate.service.ts
+++ b/src/core/gp-translate.service.ts
@@ -142,7 +142,13 @@ export class GpTranslateService {
             if (resourceMap && resourceMap[key]) {
                 return this.interpolatedText(resourceMap[key], values);
             } else {
-              return key;
+                return this.getResourceStrings(bundleParam, this._config.defaultLang).then((defaultResourceMap) => {
+                    if (defaultResourceMap && defaultResourceMap[key]) {
+                        return this.interpolatedText(defaultResourceMap[key], values);
+                    } else {
+                        return key;
+                    }
+                });
             }
         });
     }


### PR DESCRIPTION
Add functionality that covers the case when a resource string
    key may not exist for a particular language but exist in the
    default language bundle file.