### PR TITLE
ngOnDestroy in gp-translate.directive.ts

### DIFF
--- a/src/core/gp-translate.directive.ts
+++ b/src/core/gp-translate.directive.ts
@@ -155,4 +155,15 @@ export class GpTranslateDirective implements OnInit {
     ngOnInit() {
       this.getText();
     }
+
+    _dispose(): void {
+       if (this.onLangChangeSub) {
+           this.onLangChangeSub.unsubscribe();
+           this.onLangChangeSub = undefined;
+       }
+    }
+
+    ngOnDestroy(): void {
+        this._dispose();
+    }
 }


### PR DESCRIPTION
Hello,
Shouldn't you call the `this.onLangChangeSub.unsubscribe();` in the directive the same way as in the pipe?

P.S.
Perhaps, it would be even better if it does not create the subscription.
